### PR TITLE
ci: add flake checks, dependabot, and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,14 @@
+name: Auto Merge Dependency Updates
+on:
+  - pull_request_target
+jobs:
+  auto-merge-dependency-updates:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: "auto-merge:${{ github.head_ref }}"
+      cancel-in-progress: true
+    steps:
+      - uses: Mic92/auto-merge@main

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       treefmt-nix,
       ...
@@ -32,6 +33,27 @@
         };
       });
 
-      formatter = eachSystem (pkgs: import ./nix/fmt.nix { inherit pkgs treefmt-nix; });
+      formatter = eachSystem (
+        pkgs: (import ./nix/fmt.nix { inherit pkgs treefmt-nix; }).config.build.wrapper
+      );
+
+      checks = eachSystem (
+        pkgs:
+        let
+          zfs-dedup = pkgs.callPackage ./nix/package.nix { };
+          treefmt = import ./nix/fmt.nix { inherit pkgs treefmt-nix; };
+        in
+        {
+          inherit zfs-dedup;
+          clippy = zfs-dedup.overrideAttrs (old: {
+            pname = "zfs-dedup-clippy";
+            nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clippy ];
+            buildPhase = "cargo clippy --all-targets -- -D warnings";
+            doCheck = false;
+            installPhase = "touch $out";
+          });
+          formatting = treefmt.config.build.check self;
+        }
+      );
     };
 }

--- a/nix/fmt.nix
+++ b/nix/fmt.nix
@@ -1,6 +1,6 @@
 { pkgs, treefmt-nix }:
-(treefmt-nix.lib.evalModule pkgs {
+treefmt-nix.lib.evalModule pkgs {
   projectRootFile = "flake.nix";
   programs.nixfmt.enable = true;
   programs.rustfmt.enable = true;
-}).config.build.wrapper
+}


### PR DESCRIPTION

checks: package build (with tests), clippy -D warnings, treefmt.
Buildbot picks up checks.* automatically. Dependabot keeps cargo,
GitHub Actions, and the nix flake lock current; auto-merge lands
green dependency PRs.
