### PR TITLE
walk: discover mounts from mountinfo, not the mountpoint property

### DIFF
--- a/src/remount.rs
+++ b/src/remount.rs
@@ -28,12 +28,16 @@ pub fn enter_private_mount_ns() -> Result<()> {
     Ok(())
 }
 
-struct Mount {
-    point: PathBuf,
+pub(crate) struct Mount {
+    pub(crate) point: PathBuf,
+    // Path within the source filesystem; "/" for a dataset root,
+    // something else for a bind mount of a subtree.
+    pub(crate) root: PathBuf,
+    pub(crate) source: String,
     flags: MountFlags,
     ro: bool,
     super_rw: bool,
-    fstype: String,
+    pub(crate) fstype: String,
 }
 
 // mountinfo escapes space/tab/newline/backslash as \040 etc.
@@ -54,16 +58,20 @@ fn unescape(s: &str) -> PathBuf {
 
 // /proc/self/mountinfo line:
 //   id parent maj:min root mountpoint opts [optional...] - fstype src superopts
-fn parse_mountinfo(line: &str) -> Option<Mount> {
+pub(crate) fn parse_mountinfo(line: &str) -> Option<Mount> {
     let (head, tail) = line.split_once(" - ")?;
     let mut h = head.split(' ');
-    let point = unescape(h.nth(4)?);
+    let root = unescape(h.nth(3)?);
+    let point = unescape(h.next()?);
     let opts = h.next()?;
     let mut t = tail.split(' ');
     let fstype = t.next()?.to_owned();
-    let super_opts = t.nth(1)?;
+    let source = t.next()?.to_owned();
+    let super_opts = t.next()?;
     Some(Mount {
         point,
+        root,
+        source,
         flags: opts.split(',').filter_map(opt_flag).collect(),
         ro: opts.split(',').any(|o| o == "ro"),
         super_rw: super_opts.split(',').any(|o| o == "rw"),
@@ -123,6 +131,8 @@ mod tests {
         let l = "54 39 0:33 /nix/store /nix/store ro,nosuid,nodev,relatime shared:17 - zfs zroot/root/nixos rw,xattr,posixacl,casesensitive";
         let m = parse_mountinfo(l).unwrap();
         assert_eq!(m.point, Path::new("/nix/store"));
+        assert_eq!(m.root, Path::new("/nix/store"));
+        assert_eq!(m.source, "zroot/root/nixos");
         assert!(m.ro);
         assert!(m.super_rw);
         assert_eq!(m.fstype, "zfs");

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -152,22 +152,27 @@ fn cloneable_pools() -> Result<HashSet<String>> {
 }
 
 // Mountpoints of every mounted ZFS dataset on a block_cloning pool.
+// Read from mountinfo, not the `mountpoint` property, so legacy mounts
+// (fstab roots, docker's zfs graph driver) are found too. Subtree bind
+// mounts (root != "/") are skipped; the dataset root already covers them.
 pub fn zfs_mounts() -> Result<Vec<PathBuf>> {
     let pools = cloneable_pools()?;
-    let out = zfs_cmd(
-        "zfs",
-        &["list", "-H", "-t", "filesystem", "-o", "name,mountpoint"],
-    )?;
-    Ok(out
+    let mountinfo =
+        std::fs::read_to_string("/proc/self/mountinfo").context("read /proc/self/mountinfo")?;
+    Ok(zfs_mountpoints(&mountinfo, &pools))
+}
+
+fn zfs_mountpoints(mountinfo: &str, pools: &HashSet<String>) -> Vec<PathBuf> {
+    mountinfo
         .lines()
-        .filter_map(|l| l.split_once('\t'))
-        .filter(|(ds, mp)| {
-            mp.starts_with('/') && pools.contains(ds.split('/').next().unwrap_or(ds))
+        .filter_map(crate::remount::parse_mountinfo)
+        .filter(|m| {
+            m.fstype == "zfs"
+                && m.root == Path::new("/")
+                && pools.contains(m.source.split('/').next().unwrap_or(&m.source))
         })
-        .map(|(_, mp)| PathBuf::from(mp))
-        // Datasets can have a mountpoint set but not be mounted.
-        .filter(|p| is_zfs(p))
-        .collect())
+        .map(|m| m.point)
+        .collect()
 }
 
 // Per-dataset filesystem id from statvfs. ZFS derives this from the
@@ -292,6 +297,27 @@ fn walk_root(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mounts_include_legacy_and_skip_binds_and_foreign() {
+        let mountinfo = "\
+39 1 0:33 / / rw,noatime shared:1 - zfs zroot/root/nixos rw,xattr,posixacl
+54 39 0:33 /nix/store /nix/store ro,nosuid,nodev shared:17 - zfs zroot/root/nixos rw,xattr
+60 39 0:40 / /var/lib/docker/zfs/graph/abc rw,relatime - zfs zroot/docker/abc rw,xattr
+61 39 0:41 / /zroot rw,noatime - zfs zroot rw,xattr
+62 39 0:50 / /old ro,relatime - zfs oldpool/data ro,xattr
+63 39 259:1 / /boot rw,relatime - vfat /dev/nvme0n1p1 rw";
+        let pools: HashSet<String> = ["zroot".to_owned()].into();
+        let got = zfs_mountpoints(mountinfo, &pools);
+        assert_eq!(
+            got,
+            vec![
+                PathBuf::from("/"),
+                PathBuf::from("/var/lib/docker/zfs/graph/abc"),
+                PathBuf::from("/zroot"),
+            ]
+        );
+    }
 
     #[test]
     fn filtering() {


### PR DESCRIPTION

Datasets mounted with mountpoint=legacy (fstab-managed NixOS roots,
docker's zfs graph driver) never show a path in `zfs list -o
mountpoint`, so zfs-dedup found nothing to scan on such systems even
though the pool supports block cloning.

Read /proc/self/mountinfo instead: any mounted zfs filesystem whose
pool has block_cloning is eligible. Bind mounts of a subtree
(mountinfo root != /) are skipped since the dataset root mount already
covers those files.
