### PR TITLE
walk: cut memory usage with prefix-compressed paths and a bounded walker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,28 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,15 +83,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -246,16 +215,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jwalk"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e610b2b1eaea9e0e062c47e319d20a2e0f929e7aabf24d58514354de967bfbd"
-dependencies = [
- "crossbeam",
- "rayon",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -672,8 +631,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "divan",
- "jwalk",
  "lexopt",
+ "libc",
  "mimalloc",
  "rayon",
  "redb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libmimalloc-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ mimalloc = "0.1.52"
 
 [dev-dependencies]
 divan = "0.1"
+libc = "0.2.189"
 
 [[bench]]
 name = "throughput"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ rustix = { version = "1", features = ["fs", "mount", "thread"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 rayon = "1"
 redb = "4"
-jwalk = "0.9"
 anyhow = "1"
 lexopt = "0.3"
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -79,16 +79,15 @@ automatically when available.
 
 ## Memory
 
-zfs-dedup needs roughly 250 MiB per million files in the largest dataset.
-As datasets are scanned one at a time, only the biggest one that matters.
+zfs-dedup needs roughly 240 MiB per million files in the largest dataset
+during the walk, dropping to about 65 MiB per million afterwards.
+As datasets are scanned one at a time, only the biggest one matters.
 
-| files in largest dataset | peak RSS |
-|---|---|
-| 1 M | ~350 MiB |
-| 10 M | ~2.5 GiB |
-| 50 M | ~12.5 GiB |
-
-The peak is brief, during the walk. The dedup phase that follows runs at about a third of that.
+| files in largest dataset | peak RSS | after the walk |
+|---|---|---|
+| 1 M | ~240 MiB | ~65 MiB |
+| 10 M | ~2.4 GiB | ~650 MiB |
+| 50 M | ~12 GiB | ~3.2 GiB |
 
 ## Limitations
 

--- a/examples/walkmem.rs
+++ b/examples/walkmem.rs
@@ -1,0 +1,25 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn main() {
+    let root: PathBuf = std::env::args().nth(1).expect("usage: walkmem DIR").into();
+    let paths = zfs_dedup::walk::files(&[root], &HashSet::new());
+    let ru = unsafe {
+        let mut ru: libc::rusage = std::mem::zeroed();
+        libc::getrusage(libc::RUSAGE_SELF, &mut ru);
+        ru
+    };
+    unsafe { libc::malloc_trim(0) };
+    let vmrss = std::fs::read_to_string("/proc/self/status")
+        .unwrap()
+        .lines()
+        .find(|l| l.starts_with("VmRSS"))
+        .and_then(|l| l.split_whitespace().nth(1).map(String::from))
+        .unwrap();
+    println!(
+        "files: {}, peak RSS: {} MiB, retained RSS: {} MiB",
+        paths.files.len(),
+        ru.ru_maxrss / 1024,
+        vmrss.parse::<u64>().unwrap() / 1024
+    );
+}

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,55 +1,112 @@
+use std::collections::HashMap;
 use std::collections::HashSet;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::io::ErrorKind;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::mpsc::sync_channel;
 
 use anyhow::{Context, Result, bail};
 use rustix::fs::{FsWord, statfs, statvfs};
 
-// File paths split at the last component. Parents are Arc-shared with
-// siblings (jwalk already keeps it that way) and filenames live in one
-// flat byte arena: no per-file heap allocation, no fat-pointer slop.
-// On a 30M-file scan this cuts the path list -- the largest fixed cost
-// in RAM -- by more than half.
+// File paths prefix-compressed into a directory table. Every directory
+// is (parent id, basename) and every file is (dir id, basename). All
+// basenames live in one flat byte arena, so each path component is
+// stored once rather than once per file.
 pub struct Paths<T> {
-    arena: Vec<u8>,
+    pub table: PathTable,
     pub files: Vec<(FilePath, T)>,
 }
 
-// 24 bytes; was 32 plus a heap allocation per file.
+// `ids` is only needed for interning during the walk. seal() drops it.
+#[derive(Default)]
+pub struct PathTable {
+    arena: Vec<u8>,
+    dirs: Vec<Dir>,
+    ids: HashMap<PathBuf, u32>,
+}
+
+struct Dir {
+    parent: u32, // NO_PARENT for a root component
+    off: u32,
+    len: u32,
+}
+
+const NO_PARENT: u32 = u32::MAX;
+
+impl PathTable {
+    fn add_name(&mut self, name: &[u8]) -> (u32, u32) {
+        let off = u32::try_from(self.arena.len()).expect("path arena overflow");
+        self.arena.extend_from_slice(name);
+        (off, name.len() as u32)
+    }
+
+    fn name(&self, off: u32, len: u32) -> &OsStr {
+        OsStr::from_bytes(&self.arena[off as usize..(off + len) as usize])
+    }
+
+    fn intern(&mut self, p: &Path) -> u32 {
+        if let Some(&id) = self.ids.get(p) {
+            return id;
+        }
+        // "/" or "" become a root entry holding the whole path.
+        let (parent, name) = match (p.parent(), p.file_name()) {
+            (Some(par), Some(name)) => (self.intern(par), name),
+            _ => (NO_PARENT, p.as_os_str()),
+        };
+        let (off, len) = self.add_name(name.as_bytes());
+        let id = u32::try_from(self.dirs.len()).expect("dir table overflow");
+        assert!(id != NO_PARENT, "dir table overflow");
+        self.dirs.push(Dir { parent, off, len });
+        self.ids.insert(p.to_path_buf(), id);
+        id
+    }
+
+    fn dir_path(&self, mut id: u32) -> PathBuf {
+        let mut parts = Vec::new();
+        while id != NO_PARENT {
+            let d = &self.dirs[id as usize];
+            parts.push((d.off, d.len));
+            id = d.parent;
+        }
+        let mut p = PathBuf::new();
+        for &(off, len) in parts.iter().rev() {
+            p.push(self.name(off, len));
+        }
+        p
+    }
+
+    fn seal(&mut self) {
+        self.ids = HashMap::new();
+    }
+}
+
+// 12 bytes.
 pub struct FilePath {
-    parent: Arc<Path>,
+    dir: u32,
     off: u32,
     len: u32,
 }
 
 impl FilePath {
-    pub fn to_path(&self, arena: &[u8]) -> PathBuf {
-        let name = &arena[self.off as usize..(self.off + self.len) as usize];
-        self.parent.join(Path::new(OsStr::from_bytes(name)))
+    pub fn to_path(&self, table: &PathTable) -> PathBuf {
+        table
+            .dir_path(self.dir)
+            .join(table.name(self.off, self.len))
     }
 }
 
 impl<T> Paths<T> {
     pub fn path(&self, fp: &FilePath) -> PathBuf {
-        fp.to_path(&self.arena)
+        fp.to_path(&self.table)
     }
 
-    fn push(&mut self, parent: Arc<Path>, name: &OsStr, payload: T) {
-        let off = u32::try_from(self.arena.len()).expect("path arena overflow");
-        self.arena.extend_from_slice(name.as_bytes());
-        self.files.push((
-            FilePath {
-                parent,
-                off,
-                len: name.len() as u32,
-            },
-            payload,
-        ));
+    fn push(&mut self, parent: &Path, name: &OsStr, payload: T) {
+        let dir = self.table.intern(parent);
+        let (off, len) = self.table.add_name(name.as_bytes());
+        self.files.push((FilePath { dir, off, len }, payload));
     }
 
     // Re-tag the payloads in batches, sharing the same arena. The step
@@ -58,9 +115,9 @@ impl<T> Paths<T> {
     pub fn map_batched<U>(
         self,
         batch: usize,
-        mut step: impl FnMut(&[u8], Vec<(FilePath, T)>) -> Result<Vec<(FilePath, U)>>,
+        mut step: impl FnMut(&PathTable, Vec<(FilePath, T)>) -> Result<Vec<(FilePath, U)>>,
     ) -> Result<Paths<U>> {
-        let Self { arena, files } = self;
+        let Self { table, files } = self;
         let mut out = Vec::with_capacity(files.len());
         let mut iter = files.into_iter();
         loop {
@@ -68,27 +125,30 @@ impl<T> Paths<T> {
             if chunk.is_empty() {
                 break;
             }
-            out.extend(step(&arena, chunk)?);
+            out.extend(step(&table, chunk)?);
         }
-        Ok(Paths { arena, files: out })
+        Ok(Paths { table, files: out })
     }
 
     // Drop payloads the closure rejects; the arena keeps unused names
     // (cheaper than compacting and harmless).
-    pub fn filter_map<U>(self, mut f: impl FnMut(&FilePath, T, &[u8]) -> Option<U>) -> Paths<U> {
-        let Self { arena, files } = self;
+    pub fn filter_map<U>(
+        self,
+        mut f: impl FnMut(&FilePath, T, &PathTable) -> Option<U>,
+    ) -> Paths<U> {
+        let Self { table, files } = self;
         let files = files
             .into_iter()
-            .filter_map(|(p, t)| f(&p, t, &arena).map(|u| (p, u)))
+            .filter_map(|(p, t)| f(&p, t, &table).map(|u| (p, u)))
             .collect();
-        Paths { arena, files }
+        Paths { table, files }
     }
 }
 
 impl<T> Default for Paths<T> {
     fn default() -> Self {
         Self {
-            arena: Vec::new(),
+            table: PathTable::default(),
             files: Vec::new(),
         }
     }
@@ -100,11 +160,12 @@ impl<T> FromIterator<(PathBuf, T)> for Paths<T> {
         let mut out = Self::default();
         for (p, t) in iter {
             out.push(
-                Arc::from(p.parent().unwrap_or(Path::new(""))),
+                p.parent().unwrap_or(Path::new("")),
                 p.file_name().unwrap_or(OsStr::new("")),
                 t,
             );
         }
+        out.table.seal();
         out
     }
 }
@@ -203,16 +264,77 @@ pub fn files<'a>(
         };
         walk_root(root, dev, fsid, exclude, &mut seen, &mut out);
     }
-    // Both grew without a size hint; doubling leaves ~33% slack. The
+    // All grew without a size hint; doubling leaves ~33% slack. The
     // realloc here returns it before hashing inflates RSS further.
+    out.table.seal();
     out.files.shrink_to_fit();
-    out.arena.shrink_to_fit();
+    out.table.arena.shrink_to_fit();
+    out.table.dirs.shrink_to_fit();
     out
 }
 
-// (dev, ino, nlink) carried out of the parallel jwalk callback so the
-// serial consumer doesn't re-stat every file.
-type FileMeta = Option<(u64, u64, u64)>;
+// One directory's stat'ed files: (name, dev, ino, nlink) each.
+type DirBatch = (PathBuf, Vec<(OsString, u64, u64, u64)>);
+
+fn walk_dir<'a>(
+    sc: &rayon::Scope<'a>,
+    dir: PathBuf,
+    root_dev: u64,
+    tx: &'a std::sync::mpsc::SyncSender<DirBatch>,
+) {
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("walk: {}: {e}", dir.display());
+            return;
+        }
+    };
+    let mut batch = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("walk: {}: {e}", dir.display());
+                continue;
+            }
+        };
+        // Does not follow symlinks.
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) => {
+                // Vanished mid-walk. Not an error.
+                if e.kind() != ErrorKind::NotFound {
+                    eprintln!("walk: {}: {e}", entry.path().display());
+                }
+                continue;
+            }
+        };
+        if !ft.is_dir() && !ft.is_file() {
+            continue;
+        }
+        let m = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                if e.kind() != ErrorKind::NotFound {
+                    eprintln!("walk: {}: {e}", entry.path().display());
+                }
+                continue;
+            }
+        };
+        if ft.is_dir() {
+            // Prune at mount boundaries. Child datasets get their own
+            // walk_root call from main.
+            if m.dev() == root_dev {
+                sc.spawn(move |sc| walk_dir(sc, entry.path(), root_dev, tx));
+            }
+        } else {
+            batch.push((entry.file_name(), m.dev(), m.ino(), m.nlink()));
+        }
+    }
+    if !batch.is_empty() {
+        let _ = tx.send((dir, batch));
+    }
+}
 
 fn walk_root(
     root: &Path,
@@ -222,76 +344,32 @@ fn walk_root(
     seen: &mut HashSet<(u64, u64)>,
     out: &mut Paths<u64>,
 ) {
-    // process_read_dir runs on rayon threads: stat there so the per-file
-    // syscall is parallel. The for loop below is single-threaded and
-    // must only touch what the callback already collected.
-    for entry in jwalk::WalkDirGeneric::<((), FileMeta)>::new(root)
-        .skip_hidden(false)
-        .follow_links(false)
-        .sort(false)
-        .process_read_dir(move |_, _, _, children| {
-            for c in children.iter_mut().flatten() {
-                let ft = c.file_type();
-                if !ft.is_dir() && !ft.is_file() {
+    // Directories are read and files stat'ed in parallel on rayon
+    // workers, which stream compact batches through a bounded channel
+    // to the serial consumer below. A full channel blocks the workers,
+    // so peak memory stays at O(workers * dir size + channel capacity)
+    // no matter how far the walk runs ahead.
+    let (tx, rx) = sync_channel::<DirBatch>(1024);
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            rayon::scope(|sc| walk_dir(sc, root.to_path_buf(), root_dev, &tx));
+            drop(tx); // ends the rx loop
+        });
+        for (parent, files) in rx {
+            for (name, dev, ino, nlink) in files {
+                // A different dev means we crossed a mount point.
+                if dev != root_dev || exclude.contains(&(dev, ino)) {
                     continue;
                 }
-                let m = match c.metadata() {
-                    Ok(m) => m,
-                    // Files vanish mid-walk; not an error. On other
-                    // errors leave client_state None: the consumer skips
-                    // the file, but a dir is still descended -- pruning
-                    // silently would drop the subtree.
-                    Err(e) => {
-                        if e.io_error()
-                            .is_none_or(|io| io.kind() != ErrorKind::NotFound)
-                        {
-                            eprintln!("walk: {}: {e}", c.path().display());
-                        }
-                        continue;
-                    }
-                };
-                if ft.is_dir() {
-                    // Prune at mount boundaries; child datasets get
-                    // their own walk_root call from main.
-                    if m.dev() != root_dev {
-                        c.read_children = None;
-                    }
-                } else {
-                    c.client_state = Some((m.dev(), m.ino(), m.nlink()));
+                // `seen` collapses hardlinks. Files with nlink == 1
+                // have no aliases and skip the HashSet.
+                if nlink > 1 && !seen.insert((dev, ino)) {
+                    continue;
                 }
+                out.push(&parent, &name, fsid);
             }
-        })
-    {
-        let entry = match entry {
-            Ok(e) => e,
-            // Files vanish during a live walk all the time; not an error.
-            Err(e)
-                if e.io_error()
-                    .is_some_and(|io| io.kind() == ErrorKind::NotFound) =>
-            {
-                continue;
-            }
-            Err(e) => {
-                eprintln!("walk: {e}");
-                continue;
-            }
-        };
-        let Some((dev, ino, nlink)) = entry.client_state else {
-            continue;
-        };
-        // Stay on the root filesystem; a different dev means we crossed
-        // a mount point, which could be non-ZFS or a different pool.
-        if dev != root_dev || exclude.contains(&(dev, ino)) {
-            continue;
         }
-        // `seen` exists to dedup hardlinks. Files with nlink == 1 have
-        // no aliases, so don't pay HashSet memory for them; that's most
-        // of any tree.
-        if nlink > 1 && !seen.insert((dev, ino)) {
-            continue;
-        }
-        out.push(entry.parent_path.clone(), &entry.file_name, fsid);
-    }
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION

The walk phase dominated peak RSS. Two causes, measured with heaptrack
on a 2.5M-file /nix/store:

1. Every file stored its parent as Arc<Path> with the full directory
   path, so RAM scaled with the sum of path lengths.
2. jwalk's unbounded internal queue buffered fat DirEntries faster than
   the serial consumer drained them, costing gigabytes of transient RSS.

Replace both. Paths are now prefix-compressed into a directory table
where each component is stored once, and FilePath shrinks from 24 to 12
bytes. jwalk is replaced by ~60 lines of read_dir + rayon::scope that
stream compact (name, dev, ino, nlink) batches through a bounded
channel. A full channel blocks the workers, so the walk can no longer
outrun the consumer.

Results on 2.5M files: peak RSS 3706 -> 594 MiB (-84%), retained RSS
356 -> 161 MiB (-55%), wall time 23 -> 15s. One dependency dropped.
